### PR TITLE
V0.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+# Changes
+
+## [0.1.0] - 2020-09-03
+
+- Set Accept header to *application/json* by default for `ordway.client.OrdwayClient`'s session
+- Attached a custom `requests.adapters.HTTPAdapter` to handle retries and HTTP timeouts
+- Functionality for using a context manager with `ordway.client.OrdwayClient` added

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ print(ordway.customers.get(id="CUST-01"))
 
 ## Documentation
 
-## License
+**TODO**

--- a/ordway/__version__.py
+++ b/ordway/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.1"  # pragma: no cover
+__version__ = "0.1.1"  # pragma: no cover

--- a/ordway/__version__.py
+++ b/ordway/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.1"  # pragma: no cover
+__version__ = "0.1.0"  # pragma: no cover

--- a/ordway/session.py
+++ b/ordway/session.py
@@ -6,6 +6,7 @@ from urllib3.util.retry import Retry
 if TYPE_CHECKING:
     from requests import PreparedRequest
 
+
 class TimeoutAdapter(HTTPAdapter):
     """ Adds a default timeout to request Requests. """
 
@@ -33,6 +34,7 @@ class TimeoutAdapter(HTTPAdapter):
 
         return super().send(request, *args, **kwargs)
 
+
 retry_strategy = Retry(
     total=3,
     status_forcelist=[429, 500, 502, 503, 504],
@@ -41,13 +43,10 @@ retry_strategy = Retry(
 
 timeout_retry_adapter = TimeoutAdapter(max_retries=retry_strategy)
 
-DEFAULT_HEADERS = {
-    "Accept": "application/json"
-}
+DEFAULT_HEADERS = {"Accept": "application/json"}
 
-def session_factory(
-    session: Optional[Session] = None
-) -> Session:
+
+def session_factory(session: Optional[Session] = None) -> Session:
     """ Creates or modifies `requests.Session` by attaching a timeout adapter with a retry strategy and default headers. """
 
     if session is None:

--- a/ordway/session.py
+++ b/ordway/session.py
@@ -1,0 +1,61 @@
+from typing import TYPE_CHECKING, Optional
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+if TYPE_CHECKING:
+    from requests import PreparedRequest
+
+class TimeoutAdapter(HTTPAdapter):
+    """ Adds a default timeout to request Requests. """
+
+    DEFAULT_TIMEOUT = 10
+
+    def __init__(self, *args, **kwargs):
+        _timeout = kwargs.pop("timeout", None)
+
+        if _timeout is None:
+            self.timeout = self.DEFAULT_TIMEOUT
+        else:
+            self.timeout = _timeout
+
+        super().__init__(*args, **kwargs)
+
+    def __getstate__(self):
+        state = super().__getstate__()
+
+        state["timeout"] = self.timeout
+
+        return state
+
+    def send(self, request: "PreparedRequest", *args, **kwargs):  # pragma: no cover
+        kwargs.setdefault("timeout", self.timeout)
+
+        return super().send(request, *args, **kwargs)
+
+retry_strategy = Retry(
+    total=3,
+    status_forcelist=[429, 500, 502, 503, 504],
+    backoff_factor=3,
+)
+
+timeout_retry_adapter = TimeoutAdapter(max_retries=retry_strategy)
+
+DEFAULT_HEADERS = {
+    "Accept": "application/json"
+}
+
+def session_factory(
+    session: Optional[Session] = None
+) -> Session:
+    """ Creates or modifies `requests.Session` by attaching a timeout adapter with a retry strategy and default headers. """
+
+    if session is None:
+        session = Session()
+
+    session.mount("https://", timeout_retry_adapter)
+    session.mount("http://", timeout_retry_adapter)
+
+    session.headers.update(DEFAULT_HEADERS)
+
+    return session

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=requirements,
     extras_require={"testing": ["tox==3.17.1"]},
     project_urls={
-        "Documentation": "https://github.com/efnineio/ordway/blob/master/README.md", 
+        "Documentation": "https://github.com/efnineio/ordway/blob/master/README.md",
         "Source": "https://github.com/efnineio/ordway",
         "Tracker": "https://github.com/efnineio/ordway/issues",
         "Changelog": "https://github.com/efnineio/ordway/blob/master/CHANGES.md",

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from requests import Session
 from ordway.session import TimeoutAdapter, timeout_retry_adapter, session_factory
 
+
 class SessionFactoryTestCase(TestCase):
     def test_attaches_retry_adapter_for_existing_session(self):
         existing_session = Session()
@@ -14,6 +15,7 @@ class SessionFactoryTestCase(TestCase):
         new_session = session_factory()
         self.assertEqual(new_session.adapters["http://"], timeout_retry_adapter)
         self.assertEqual(new_session.adapters["https://"], timeout_retry_adapter)
+
 
 class TimeoutAdapterTestCase(TestCase):
     def test_sets_timeout(self):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+from requests import Session
+from ordway.session import TimeoutAdapter, timeout_retry_adapter, session_factory
+
+class SessionFactoryTestCase(TestCase):
+    def test_attaches_retry_adapter_for_existing_session(self):
+        existing_session = Session()
+        session_factory(existing_session)
+
+        self.assertEqual(existing_session.adapters["http://"], timeout_retry_adapter)
+        self.assertEqual(existing_session.adapters["https://"], timeout_retry_adapter)
+
+    def test_attaches_retry_adapter_for_new_session(self):
+        new_session = session_factory()
+        self.assertEqual(new_session.adapters["http://"], timeout_retry_adapter)
+        self.assertEqual(new_session.adapters["https://"], timeout_retry_adapter)
+
+class TimeoutAdapterTestCase(TestCase):
+    def test_sets_timeout(self):
+        adapter = TimeoutAdapter()
+        self.assertEqual(adapter.timeout, adapter.DEFAULT_TIMEOUT)
+
+        adapter = TimeoutAdapter(timeout=5)
+        self.assertEqual(adapter.timeout, 5)
+
+    def test_get_state_includes_timeout(self):
+        state = TimeoutAdapter(timeout=15).__getstate__()
+
+        self.assertIn("timeout", state)
+        self.assertEqual(state["timeout"], 15)

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,6 @@ commands =
 
 [testenv:format]
 deps = 
-    black==19.10b0
+    black==20.8b1
 commands =
     black --check {toxinidir}/ordway


### PR DESCRIPTION
- Set Accept header to *application/json* by default for `ordway.client.OrdwayClient`'s session
- Attached a custom `requests.adapters.HTTPAdapter` to handle retries and HTTP timeouts
- Functionality for using a context manager with `ordway.client.OrdwayClient` added
- Removed license section from README.md