### PR TITLE
Datetime serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ for subscription in ordway.subscriptions.list(
 
 print(ordway.customers.get(id="CUST-01"))
 
-ordway.customers.create(json={
+ordway.customers.create(data={
     "name": "Jason",
     "description": "Hello",
     "contacts": [{

--- a/ordway/__version__.py
+++ b/ordway/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.4.1"  # pragma: no cover
+__version__ = "0.5.0"  # pragma: no cover

--- a/ordway/api/base.py
+++ b/ordway/api/base.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Optional, List, Dict, Any, Generator, Union, T
 from logging import getLogger
 from requests.exceptions import RequestException
 from ordway.consts import API_ENDPOINT_BASE, STAGING_ENDPOINT_BASE
+from ordway.utils import transform_datetimes
 
 from .exceptions import OrdwayAPIRequestException, OrdwayAPIException
 
@@ -45,6 +46,8 @@ class APIBase:
             base = STAGING_ENDPOINT_BASE
         else:
             base = API_ENDPOINT_BASE
+
+        json, data = transform_datetimes(json), transform_datetimes(data)
 
         url = f"{base}/v{self.client.api_version}/{endpoint}"
 
@@ -227,11 +230,11 @@ class CreateAPIMixin(APIBase):
     """ Mixin for creating a single Ordway resource. """
 
     def create(
-        self, json: Optional[Dict[str, Any]], params: Optional[Dict[str, str]] = None
+        self, data: Optional[Dict[str, Any]], params: Optional[Dict[str, str]] = None
     ) -> _Response:
         """ Create a new resource """
 
-        return self._post_request(self.collection, json=json, data=None, params=params)
+        return self._post_request(self.collection, json=data, data=None, params=params)
 
 
 class UpdateAPIMixin(APIBase):
@@ -240,13 +243,13 @@ class UpdateAPIMixin(APIBase):
     def update(
         self,
         id: str,
-        json: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
         params: Optional[Dict[str, str]] = None,
     ) -> _Response:
         """ Update a resource identified by `id`. """
 
         return self._put_request(
-            f"{self.collection}/{id}", json=json, data=None, params=params
+            f"{self.collection}/{id}", json=data, data=None, params=params
         )
 
 

--- a/ordway/api/endpoints.py
+++ b/ordway/api/endpoints.py
@@ -43,10 +43,10 @@ class Invoices(ListAPIMixin, GetAPIMixin):
             f"{self.collection}/{id}/reverse", json={"reversed_on": reversed_on}
         )
 
-    def refund(self, id: str, json: Dict[str, Any]):
+    def refund(self, id: str, data: Dict[str, Any]):
         """ Refund a negative invoice """
 
-        return self._put_request(f"{self.collection}/{id}/refund", json=json)
+        return self._put_request(f"{self.collection}/{id}/refund", json=data)
 
 
 class Customers(
@@ -75,10 +75,10 @@ class Payments(ListAPIMixin, GetAPIMixin, CreateAPIMixin):
             f"{self.collection}/{id}/reverse", json={"reversed_on": reversed_on}
         )
 
-    def refund(self, id: str, json: Dict[str, Any]):
+    def refund(self, id: str, data: Dict[str, Any]):
         """ Refund a payment """
 
-        return self._put_request(f"{self.collection}/{id}/refund", json=json)
+        return self._put_request(f"{self.collection}/{id}/refund", json=data)
 
 
 class PaymentRuns(ListAPIMixin, GetAPIMixin, CreateAPIMixin):
@@ -112,10 +112,10 @@ class Credits(ListAPIMixin, GetAPIMixin, CreateAPIMixin):
             f"{self.collection}/{id}/reverse", json={"reversed_on": reversed_on}
         )
 
-    def refund(self, id: str, json: Dict[str, Any]):
+    def refund(self, id: str, data: Dict[str, Any]):
         """ Refund a credit """
 
-        return self._put_request(f"{self.collection}/{id}/refund", json=json)
+        return self._put_request(f"{self.collection}/{id}/refund", json=data)
 
 
 class Refunds(ListAPIMixin, GetAPIMixin):
@@ -168,32 +168,32 @@ class Subscriptions(
 
     collection = "subscriptions"
 
-    def activate(self, id: str, json: Dict[str, Any]):
+    def activate(self, id: str, data: Dict[str, Any]):
         """ Activate a subscription """
 
-        return self._put_request(f"{self.collection}/{id}/activate", json=json)
+        return self._put_request(f"{self.collection}/{id}/activate", json=data)
 
-    def cancel(self, id: str, json: Dict[str, Any]):
+    def cancel(self, id: str, data: Dict[str, Any]):
         """ Cancel a subscription """
 
-        return self._put_request(f"{self.collection}/{id}/cancel", json=json)
+        return self._put_request(f"{self.collection}/{id}/cancel", json=data)
 
-    def renew(self, id: str, json: Dict[str, Any], callback_url: Optional[str] = None):
+    def renew(self, id: str, data: Dict[str, Any], callback_url: Optional[str] = None):
         """ Renew a subscription """
 
         params = {"callback_url": callback_url} if callback_url is not None else None
 
         return self._put_request(
-            f"{self.collection}/{id}/cancel", json=json, params=params
+            f"{self.collection}/{id}/cancel", json=data, params=params
         )
 
-    def change(self, id: str, json: Dict[str, Any], callback_url: Optional[str] = None):
+    def change(self, id: str, data: Dict[str, Any], callback_url: Optional[str] = None):
         """ Change an active subscription """
 
         params = {"callback_url": callback_url} if callback_url is not None else None
 
         return self._put_request(
-            f"{self.collection}/{id}/change", json=json, params=params
+            f"{self.collection}/{id}/change", json=data, params=params
         )
 
 
@@ -205,10 +205,10 @@ class Orders(ListAPIMixin, GetAPIMixin, CreateAPIMixin, UpdateAPIMixin):
 
     collection = "orders"
 
-    def cancel(self, id: str, json: Optional[Dict[str, Any]] = None):
+    def cancel(self, id: str, data: Optional[Dict[str, Any]] = None):
         """ Cancel an order """
 
-        return self._put_request(f"{self.collection}/{id}/cancel", json=json)
+        return self._put_request(f"{self.collection}/{id}/cancel", json=data)
 
 
 class Usages(ListAPIMixin, GetAPIMixin, CreateAPIMixin, DeleteAPIMixin):
@@ -264,11 +264,11 @@ class BillingSchedules(ListAPIMixin, GetAPIMixin, UpdateAPIMixin):
 
     collection = "billing_schedules"
 
-    def manage_prepayment_lines(self, id: str, json: Dict[str, Any]):
+    def manage_prepayment_lines(self, id: str, data: Dict[str, Any]):
         """ Manage prepaid credits, allowing addition or refund of prepaid credits """
 
         return self._put_request(
-            f"{self.collection}/{id}/manage_prepayment_lines", json=json
+            f"{self.collection}/{id}/manage_prepayment_lines", json=data
         )
 
 

--- a/ordway/utils.py
+++ b/ordway/utils.py
@@ -1,0 +1,20 @@
+from typing import Any
+from datetime import datetime, date
+
+
+def transform_datetimes(data: Any) -> Any:
+    """ Converts any date or datetime objects to string via their `isoformat` methods. """
+
+    if isinstance(data, (datetime, date)):
+        return data.isoformat()
+
+    if isinstance(data, (list, tuple)):
+        tmp_data = [transform_datetimes(elem) for elem in data]
+
+        return tuple(tmp_data) if isinstance(data, tuple) else tmp_data
+
+    if isinstance(data, dict):
+        for key, val in data.items():
+            data[key] = transform_datetimes(val)
+
+    return data

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,64 @@
+from unittest import TestCase
+from requests import Session
+from datetime import datetime, date, timezone
+from ordway.utils import transform_datetimes
+
+
+class TransformDatetimes(TestCase):
+    def test_with_dict(self):
+        transformed_data = transform_datetimes(
+            {
+                "a": datetime(2020, 1, 2, tzinfo=timezone.utc),
+                "b": [[datetime(2020, 1, 2)]],
+                "c": [
+                    {
+                        "d": {
+                            "date": datetime(2020, 1, 2),
+                            "dates": [
+                                datetime(2020, 1, 2),
+                                datetime(2020, 1, 2),
+                                datetime(2020, 1, 2),
+                            ],
+                        }
+                    }
+                ],
+            }
+        )
+
+        self.assertIsInstance(transformed_data, dict)
+        self.assertDictEqual(
+            {
+                "a": "2020-01-02T00:00:00+00:00",
+                "b": [["2020-01-02T00:00:00"]],
+                "c": [
+                    {
+                        "d": {
+                            "date": "2020-01-02T00:00:00",
+                            "dates": [
+                                "2020-01-02T00:00:00",
+                                "2020-01-02T00:00:00",
+                                "2020-01-02T00:00:00",
+                            ],
+                        }
+                    }
+                ],
+            },
+            transformed_data,
+        )
+
+    def test_with_list(self):
+        transformed_data = transform_datetimes([date(2020, 1, 1), date(2019, 12, 1)])
+
+        self.assertIsInstance(transformed_data, list)
+        self.assertEqual(transformed_data, ["2020-01-01", "2019-12-01"])
+
+    def test_with_tuple(self):
+        transformed_data = transform_datetimes((date(2020, 1, 1), date(2019, 12, 1)))
+
+        self.assertIsInstance(transformed_data, tuple)
+        self.assertEqual(transformed_data, ("2020-01-01", "2019-12-01"))
+
+    def test_with_none_returns_none(self):
+        transformed_data = transform_datetimes(None)
+
+        self.assertIsNone(transformed_data)


### PR DESCRIPTION
**Changes:**
- datetime/date objects are serialized prior to being passed to `CreateAPIMixin.create`, `UpdateAPIMixin.update`, `BillingSchedules.manage_prepayment_lines`, `Orders.cancel`, `Subscriptions.activate`, `Subscriptions.cancel`, `Subscriptions.renew`, `Subscriptions.change`, `Credits.reverse`, `Credits.refund`, `Payments.refund`, and `Invoices.refund`.
- `json` kwarg renamed to `data` for all user-facing APIs