### PR TITLE
Only exhaust list if no elements are in response

### DIFF
--- a/ordway/__version__.py
+++ b/ordway/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.0"  # pragma: no cover
+__version__ = "0.5.1"  # pragma: no cover

--- a/ordway/api/base.py
+++ b/ordway/api/base.py
@@ -166,7 +166,7 @@ class ListAPIMixin(APIBase):
         for result in response_json:
             yield result
 
-        if len(response_json) < size:
+        if len(response_json) == 0:
             self._exhausted = True
 
     def all(  # pylint: disable=too-many-arguments


### PR DESCRIPTION
**Changes**:
* Fix pagination

The library would previously handle pagination by incrementing the `page` parameter until the response contained fewer elements than what was requested by the `size` parameter. Now, the library will continue pagination until there are no elements in response or the max page size has been hit.