### PR TITLE
Fixed nested API list response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [0.5.2] - 2021-08-30
+
+- Fixed `list` and `all` methods for certain collections wherein the Ordway API results are nested under the collection name. As an example API response, `{"usages": [], "total": 0}` would've previously been `[]`.
+
 ## [0.4.0] - 2020-09-22
 
 - Added support for updating following entities:

--- a/ordway/__version__.py
+++ b/ordway/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.5.1"  # pragma: no cover
+__version__ = "0.5.2"  # pragma: no cover

--- a/ordway/api/base.py
+++ b/ordway/api/base.py
@@ -160,7 +160,17 @@ class ListAPIMixin(APIBase):
         )
 
         if isinstance(response_json, dict):
-            response_json = [response_json]
+            # For some endpoints, Ordway nests the results
+            # under the collection name so as to include
+            # additional metadata
+            # For example,
+            # { "usages": [], "total": 0 }
+            results = response_json.get(self.collection.lower())
+
+            if isinstance(results, list):
+                response_json = results
+            else:
+                response_json = [response_json]
 
         # Mostly for consistency's sake.
         for result in response_json:


### PR DESCRIPTION
**Bug Fixes**:
- Fixed `list` and `all` methods for certain collections wherein the Ordway API results are nested under the collection name. As an example API response, `{"usages": [], "total": 0}` would've previously been `[]`.